### PR TITLE
Enable state Reset to playback splash animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ render() {
 | disableBackgroundImage | Disable the background image                                                                                                                                                                     | Boolean         |          |                            false                            |
 | translucent            | When translucent is set to true, the app will draw under the status bar. Example: [here](https://github.com/fabio-alss-freitas/react-native-animated-splash-screen#example-of-translucent-prop)! | Boolean         |          |                            false                            |
 | customComponent        | Add a logo component instead of a logo image.                                                                                                                                                    | React Component |          |                           `null`                            |
+| enableReset        | Allow to replay the splash animation based on the **isLoaded** prop                                                                                                                                                   | Boolean |          |                           false                            |
 
 ## Example with React Navigation
 

--- a/lib/AnimatedSplash.js
+++ b/lib/AnimatedSplash.js
@@ -14,6 +14,7 @@ import styles, {
 class AnimatedSplash extends React.Component {
   static defaultProps = {
     isLoaded: false,
+    enableReset: false
   }
 
   state = {
@@ -23,10 +24,10 @@ class AnimatedSplash extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isLoaded , duration, delay } = this.props
+    const { isLoaded , duration, delay, enableReset } = this.props
     const { loadingProgress } = this.state
 
-    if (!isLoaded && prevProps.isLoaded) {
+    if (!isLoaded && prevProps.isLoaded && enableReset) {
       loadingProgress.setValue(0)
       this.setState({animationDone: false})
     }
@@ -208,6 +209,7 @@ AnimatedSplash.propTypes = {
   duration: PropTypes.number,
   delay: PropTypes.number,
   showStatusBar: PropTypes.bool,
+  enableReset: PropTypes.bool
 }
 
 export default AnimatedSplash

--- a/lib/AnimatedSplash.js
+++ b/lib/AnimatedSplash.js
@@ -26,6 +26,11 @@ class AnimatedSplash extends React.Component {
     const { isLoaded , duration, delay } = this.props
     const { loadingProgress } = this.state
 
+    if (!isLoaded && !prevProps.isLoaded) {
+      loadingProgress.setValue(0)
+      this.setState({animationDone: false})
+    }
+
     if (isLoaded && !prevProps.isLoaded) {
       Animated.timing(loadingProgress, {
         toValue: 100,

--- a/lib/AnimatedSplash.js
+++ b/lib/AnimatedSplash.js
@@ -28,8 +28,17 @@ class AnimatedSplash extends React.Component {
     const { loadingProgress } = this.state
 
     if (!isLoaded && prevProps.isLoaded && enableReset) {
-      loadingProgress.setValue(0)
-      this.setState({animationDone: false})
+      loadingProgress.setValue(100)
+      Animated.timing(loadingProgress, {
+        toValue: 0,
+        duration: duration || 1000,
+        delay: delay || 0,
+        useNativeDriver: true,
+      }).start(() => {
+        this.setState({
+          animationDone: false,
+        })
+      })
     }
 
     if (isLoaded && !prevProps.isLoaded) {

--- a/lib/AnimatedSplash.js
+++ b/lib/AnimatedSplash.js
@@ -26,7 +26,7 @@ class AnimatedSplash extends React.Component {
     const { isLoaded , duration, delay } = this.props
     const { loadingProgress } = this.state
 
-    if (!isLoaded && !prevProps.isLoaded) {
+    if (!isLoaded && prevProps.isLoaded) {
       loadingProgress.setValue(0)
       this.setState({animationDone: false})
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-animated-splash-screen",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Enable to reset the component state, with **enableReset** prop set to true, based on the changes of **isLoaded** prop.
Usefull if you want to use this component as a lock screen etc...

Basically when **enableReset** prop is set to true the flow goes like this:
isLoaded props: 
 - **(false) -> (true)** Splash anim play and show content
 - **(true) -> (false)** Splash anim play backwards and show hides the content

See video for a demonstration

https://user-images.githubusercontent.com/1368482/133862589-11f0d20d-fa1e-408f-afbd-d04dea874e2c.mp4


